### PR TITLE
Add GROUP_CHAT_ID config + rare-pull (4-star+) group announcement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,9 @@
 # Telegram
 BOT_TOKEN=
 GACHA_TOPIC_ID=
+# The group chat's id — GACHA_TOPIC_ID alone is meaningless once pulls
+# happen in DM rather than in the chat that topic id is relative to.
+GROUP_CHAT_ID=
 ADMIN_USER_IDS=
 
 # Optional. DEBUG/INFO/WARNING/ERROR — see CLAUDE.md's Logging section.

--- a/src/ley_shards_bot/commands/gacha.py
+++ b/src/ley_shards_bot/commands/gacha.py
@@ -4,7 +4,9 @@ Thin by design (see CLAUDE.md): parse the Update, call services/gacha.py,
 format the reply. No pity/rarity/economy rules live here.
 
 DM-scoped, not group-topic-scoped — see ARCHITECTURE.md's "Commands &
-topics" section and issue #17.
+topics" section and issue #17. A 4★+ pull also gets a best-effort public
+announcement in the group's 🎰 Gacha topic (issue #18) on top of the DM
+result — see `_announce_rare_pull`.
 """
 
 from __future__ import annotations
@@ -24,7 +26,7 @@ if TYPE_CHECKING:
     from collections.abc import Callable
 
     from sqlalchemy.orm import Session
-    from telegram import Message
+    from telegram import Message, User
 
 _PullResultT = TypeVar("_PullResultT")
 
@@ -68,6 +70,33 @@ def _format_single_caption(outcome: gacha.PullOutcome) -> str:
     return "\n".join(lines)
 
 
+async def _announce_rare_pull(
+    context: ContextTypes.DEFAULT_TYPE, user: User, outcome: gacha.PullOutcome
+) -> None:
+    """Post a celebratory public message into the group's 🎰 Gacha topic
+    for a 4★+ pull, on top of — not instead of — the private DM result.
+    Best-effort: a failure here (bot not in the group, topic gone, ...)
+    must never take down the DM reply that already succeeded."""
+    if outcome.rarity not in _HIGHLIGHT_RARITIES:
+        return
+    try:
+        config = context.bot_data["config"]
+        text = (
+            f"🎉 {user.first_name} just pulled a "
+            f"{_RARITY_STARS[outcome.rarity]} {outcome.character.name}!"
+        )
+        await context.bot.send_message(
+            chat_id=config.group_chat_id, message_thread_id=config.gacha_topic_id, text=text
+        )
+    except Exception as exc:
+        logger.warning(
+            "Failed to post rare-pull announcement for player={} rarity={}: {}",
+            user.id,
+            outcome.rarity,
+            exc,
+        )
+
+
 async def _attempt_pull(
     session: Session,
     message: Message,
@@ -94,7 +123,7 @@ async def _attempt_pull(
         return None
 
 
-async def pull_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:  # noqa: ARG001
+async def pull_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     message = update.effective_message
     user = update.effective_user
     if message is None or user is None:
@@ -114,9 +143,10 @@ async def pull_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await message.reply_photo(
         photo=outcome.character.image_url, caption=_format_single_caption(outcome)
     )
+    await _announce_rare_pull(context, user, outcome)
 
 
-async def pull_ten_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:  # noqa: ARG001
+async def pull_ten_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     message = update.effective_message
     user = update.effective_user
     if message is None or user is None:
@@ -141,3 +171,4 @@ async def pull_ten_command(update: Update, context: ContextTypes.DEFAULT_TYPE) -
             await message.reply_photo(
                 photo=outcome.character.image_url, caption=_format_single_caption(outcome)
             )
+            await _announce_rare_pull(context, user, outcome)

--- a/src/ley_shards_bot/config.py
+++ b/src/ley_shards_bot/config.py
@@ -35,6 +35,7 @@ def database_url() -> str:
 class Config:
     bot_token: str
     gacha_topic_id: int
+    group_chat_id: int
     admin_user_ids: frozenset[int]
     telegram_proxy_url: str | None
     database_url: str
@@ -45,6 +46,7 @@ class Config:
         return cls(
             bot_token=_require("BOT_TOKEN"),
             gacha_topic_id=int(_require("GACHA_TOPIC_ID")),
+            group_chat_id=int(_require("GROUP_CHAT_ID")),
             admin_user_ids=_parse_admin_ids(os.environ.get("ADMIN_USER_IDS", "")),
             telegram_proxy_url=os.environ.get("TELEGRAM_PROXY_URL") or None,
             database_url=database_url(),

--- a/tests/commands/test_gacha.py
+++ b/tests/commands/test_gacha.py
@@ -12,9 +12,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
+from telegram import User
 
 from ley_shards_bot.commands import gacha as gacha_commands
-from ley_shards_bot.models import Base, Character, Player, Rarity
+from ley_shards_bot.models import BannerType, Base, Character, PityState, Player, Rarity
+from ley_shards_bot.services import gacha as gacha_service
+from ley_shards_bot.services.gacha import FIVE_STAR_HARD_PITY
 
 
 @pytest.fixture
@@ -91,11 +94,16 @@ def _seed_player(engine, telegram_user_id: int = 1, ley_shards: int = 100_000) -
 
 
 def _make_update(
-    *, user_id: int = 1, chat_type: str = "private", username: str | None = None
+    *,
+    user_id: int = 1,
+    chat_type: str = "private",
+    username: str | None = None,
+    first_name: str = "Aleksey",
 ) -> MagicMock:
     update = MagicMock()
     update.effective_user.id = user_id
     update.effective_user.username = username
+    update.effective_user.first_name = first_name
     update.effective_chat = SimpleNamespace(type=chat_type)
     message = MagicMock()
     message.reply_text = AsyncMock()
@@ -104,8 +112,13 @@ def _make_update(
     return update
 
 
-def _make_context() -> MagicMock:
-    return MagicMock()
+def _make_context(*, group_chat_id: int = -1001, gacha_topic_id: int = 5) -> MagicMock:
+    context = MagicMock()
+    context.bot_data = {
+        "config": SimpleNamespace(group_chat_id=group_chat_id, gacha_topic_id=gacha_topic_id)
+    }
+    context.bot.send_message = AsyncMock()
+    return context
 
 
 class TestPullCommand:
@@ -201,3 +214,116 @@ class TestPullTenCommand:
         (text,), _ = update.effective_message.reply_text.call_args
         assert "ley shards" in text.lower()
         assert "10-pull" not in text.lower()
+
+
+def _make_outcome(rarity: Rarity, *, character_name: str = "Frieren") -> gacha_service.PullOutcome:
+    character = Character(
+        anilist_id=99,
+        name=character_name,
+        series="Frieren: Beyond Journey's End",
+        image_url="https://example.invalid/frieren.png",
+        rarity=rarity,
+        base_hp=1,
+        base_atk=1,
+        base_def=1,
+        base_spd=1,
+    )
+    return gacha_service.PullOutcome(
+        character=character, rarity=rarity, is_new=True, echoes_gained=0, is_rate_up=None
+    )
+
+
+class TestAnnounceRarePull:
+    async def test_posts_to_the_group_gacha_topic_for_a_five_star(self):
+        context = _make_context(group_chat_id=-100999, gacha_topic_id=42)
+        user = User(id=1, first_name="Aleksey", is_bot=False)
+        outcome = _make_outcome(Rarity.FIVE_STAR)
+
+        await gacha_commands._announce_rare_pull(context, user, outcome)
+
+        context.bot.send_message.assert_awaited_once()
+        _args, kwargs = context.bot.send_message.call_args
+        assert kwargs["chat_id"] == -100999
+        assert kwargs["message_thread_id"] == 42
+        assert kwargs["text"] == "🎉 Aleksey just pulled a ★★★★★ Frieren!"
+
+    async def test_posts_for_a_four_star_too(self):
+        context = _make_context()
+        user = User(id=1, first_name="Aleksey", is_bot=False)
+        outcome = _make_outcome(Rarity.FOUR_STAR)
+
+        await gacha_commands._announce_rare_pull(context, user, outcome)
+
+        context.bot.send_message.assert_awaited_once()
+
+    async def test_does_not_post_for_a_three_star(self):
+        context = _make_context()
+        user = User(id=1, first_name="Aleksey", is_bot=False)
+        outcome = _make_outcome(Rarity.THREE_STAR)
+
+        await gacha_commands._announce_rare_pull(context, user, outcome)
+
+        context.bot.send_message.assert_not_called()
+
+    async def test_a_failed_announcement_does_not_raise(self):
+        context = _make_context()
+        context.bot.send_message.side_effect = RuntimeError("Telegram is down")
+        user = User(id=1, first_name="Aleksey", is_bot=False)
+        outcome = _make_outcome(Rarity.FIVE_STAR)
+
+        await gacha_commands._announce_rare_pull(context, user, outcome)  # must not raise
+
+    async def test_a_missing_config_does_not_raise(self):
+        context = _make_context()
+        context.bot_data = {}  # config missing from bot_data entirely
+        user = User(id=1, first_name="Aleksey", is_bot=False)
+        outcome = _make_outcome(Rarity.FIVE_STAR)
+
+        await gacha_commands._announce_rare_pull(context, user, outcome)  # must not raise
+
+        context.bot.send_message.assert_not_called()
+
+
+def _seed_hard_pity(engine, *, banner_type: BannerType, telegram_user_id: int = 1) -> None:
+    with Session(engine) as session:
+        session.add(
+            PityState(
+                player_id=telegram_user_id,
+                banner_type=banner_type,
+                pulls_since_last_5star=FIVE_STAR_HARD_PITY - 1,
+            )
+        )
+        session.commit()
+
+
+class TestRarePullGroupAnnouncement:
+    async def test_pull_command_announces_a_guaranteed_five_star(self, engine):
+        _seed_roster(engine)
+        _seed_player(engine)
+        _seed_hard_pity(engine, banner_type=BannerType.STANDARD)
+        update = _make_update(first_name="Aleksey")
+        context = _make_context(group_chat_id=-100999, gacha_topic_id=7)
+
+        await gacha_commands.pull_command(update, context)
+
+        update.effective_message.reply_photo.assert_awaited_once()  # DM result still sent
+        context.bot.send_message.assert_awaited_once()
+        _args, kwargs = context.bot.send_message.call_args
+        assert kwargs["chat_id"] == -100999
+        assert kwargs["message_thread_id"] == 7
+        assert kwargs["text"] == "🎉 Aleksey just pulled a ★★★★★ Five Star!"
+
+    async def test_pull_ten_command_announces_the_guaranteed_five_star(self, engine):
+        _seed_roster(engine)
+        _seed_player(engine)
+        _seed_hard_pity(engine, banner_type=BannerType.STANDARD)
+        update = _make_update(first_name="Aleksey")
+        context = _make_context(group_chat_id=-100999, gacha_topic_id=7)
+
+        await gacha_commands.pull_ten_command(update, context)
+
+        update.effective_message.reply_text.assert_awaited_once()  # DM summary still sent
+        assert context.bot.send_message.await_count >= 1
+        for _args, kwargs in context.bot.send_message.call_args_list:
+            assert kwargs["chat_id"] == -100999
+            assert kwargs["message_thread_id"] == 7

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,6 +17,7 @@ def _fake_config() -> Config:
     return Config(
         bot_token="123456:fake-token-for-testing",  # noqa: S106 (test fixture, not a real secret)
         gacha_topic_id=1,
+        group_chat_id=-100123,
         admin_user_ids=frozenset({1}),
         telegram_proxy_url=None,
         database_url="sqlite:///:memory:",


### PR DESCRIPTION
Closes #18

DM pulls now also post a best-effort public celebration into the group's 🎰 Gacha topic when the outcome is 4★ or better, on top of (not instead of) the private DM result. Failures in that path are caught and logged, never raised — they can't take down the DM reply that already succeeded.

- `config.py`: new required `group_chat_id` field, loaded the same way as `gacha_topic_id`.
- `commands/gacha.py`: new `_announce_rare_pull()` helper wired into both `pull_command` and `pull_ten_command`.
- `.env.example`: documents `GROUP_CHAT_ID`.

**Ops note:** `GROUP_CHAT_ID` is a newly-required env var. Already added to moscow's live `.env` (`-1004360264620`, verified via `getChat` against the actual GachaTestGroup) ahead of this merge, so the auto-deploy on merge won't crash-loop the bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)