### PR TITLE
CI: skip checks/tests/deploy on doc-only changes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,7 +2,9 @@ name: Checks
 
 on:
   push:
+    paths-ignore: ["**.md", "docs/**"]
   pull_request:
+    paths-ignore: ["**.md", "docs/**"]
 
 jobs:
   checks:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,10 +4,12 @@ name: Deploy
 # so a fork PR can't reach this workflow's secrets. Re-runs checks.yml's
 # and tests.yml's steps itself as a gate (see CLAUDE.md/the CI plan for
 # why this isn't wired as a cross-workflow `needs:` — not supported
-# across separate workflow files).
+# across separate workflow files). Doc-only merges skip this too — no
+# app code changed, nothing to redeploy.
 on:
   push:
     branches: [master]
+    paths-ignore: ["**.md", "docs/**"]
 
 jobs:
   verify:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,3 +25,4 @@ jobs:
       # never the real MariaDB the bot runs against in production.
       - name: Run tests
         run: uv run pytest -q
+

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,9 @@ name: Tests
 
 on:
   push:
+    paths-ignore: ["**.md", "docs/**"]
   pull_request:
+    paths-ignore: ["**.md", "docs/**"]
 
 jobs:
   tests:


### PR DESCRIPTION
Adds `paths-ignore: ["**.md", "docs/**"]` to `checks.yml`, `tests.yml`, and `deploy.yml`'s triggers — a doc-only push/PR/merge no longer runs Python lint/type/test/deploy at all.

GitHub supports a `[skip ci]`-style commit-message tag natively, but it's all-or-nothing per commit and easy to forget; `paths-ignore` is automatic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)