### PR TITLE
tests.yml: drop stray trailing blank line

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,4 +25,3 @@ jobs:
       # never the real MariaDB the bot runs against in production.
       - name: Run tests
         run: uv run pytest -q
-


### PR DESCRIPTION
Left over from testing whether GitHub Actions registers a new paths-ignore trigger in the same commit that introduces it (it doesn't — see #61's discussion). Purely cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)