### PR TITLE
Character constellations: duplicate-leveling before Echoes

### DIFF
--- a/MECHANICS.md
+++ b/MECHANICS.md
@@ -18,7 +18,7 @@ that's deliberately not repeated here.
 | Characters: rarity, placeholder base stats | **Implemented** (Phase 1) |
 | Character `description`/tags (AniList-sourced) | Planned (Phase 1.1) |
 | Standard/event banner tickets | Planned (Phase 1.1) |
-| Constellations (character duplicate leveling) | Planned (Phase 1.1) |
+| Constellations (character duplicate leveling) | **Implemented** (Phase 1.1) |
 | Weapons: rarity, `weapon_type`, base stats | Planned (Phase 1.2) |
 | `characters.role`/`element`, admin stat editing | Planned (Phase 1.2) |
 | Refinement (weapon duplicate leveling), weapon ticket | Planned (Phase 1.2) |
@@ -85,7 +85,7 @@ that point rather than it being computed. See `ARCHITECTURE.md`'s
 | tags | Planned (Phase 1.1) | AniList's genre/tag-ish data, stored as simple JSON/text rather than a relational tags model — no "filter by tag" requirement exists yet to justify more (YAGNI). |
 | `role`, `element` | Planned (Phase 1.2) | New enum columns. Exact taxonomy (which roles, which elements) is undecided — TBD when that ticket is picked up. |
 | `base_hp`/`base_atk`/`base_def`/`base_spd` | Implemented (placeholder) | Auto-derived deterministically at import today, purely as a forward-compatible placeholder — see `ARCHITECTURE.md`'s Roadmap. No gameplay reads these yet; that's Phase 2 (combat). Admin-editable from Phase 1.2 on, alongside `rarity`/`role`/`element`. |
-| Constellations | Planned (Phase 1.1) | 6 levels; how a character gains them is a *pull* mechanic — see `GACHA.md`'s "Duplicates: constellations, refinement, then Echoes". What each level actually **grants** (passive abilities) is Phase 2's job, once combat design exists — this phase only builds the counter. |
+| Constellations | Implemented (Phase 1.1) | 6 levels; how a character gains them is a *pull* mechanic — see `GACHA.md`'s "Duplicates: constellations, refinement, then Echoes". What each level actually **grants** (passive abilities) is Phase 2's job, once combat design exists — this phase only builds the counter. |
 
 ## Weapons (Phase 1.2)
 

--- a/src/ley_shards_bot/commands/collection.py
+++ b/src/ley_shards_bot/commands/collection.py
@@ -20,6 +20,7 @@ from ley_shards_bot.commands.helpers.formatting import RARITY_STARS
 from ley_shards_bot.commands.helpers.scoping import NOT_IN_DM_MESSAGE, in_private_chat
 from ley_shards_bot.db import session_scope
 from ley_shards_bot.services.collection import get_owned_characters
+from ley_shards_bot.services.gacha import CONSTELLATION_MAX_COPIES
 from ley_shards_bot.services.pagination import PAGE_SIZE, Page, paginate
 
 # Registered elsewhere (task #8's Application wiring) with a
@@ -52,8 +53,13 @@ def _format_page_text(page: Page, total_owned: int) -> str:
         stars = RARITY_STARS[owned.character.rarity]
         # copies_owned is constellation progress (see PlayerCharacter's
         # docstring): 1 copy = constellation 0 (no suffix shown), each
-        # copy beyond that is one constellation level.
-        constellation = f" C{owned.copies_owned - 1}" if owned.copies_owned > 1 else ""
+        # copy beyond that is one constellation level. Clamped at
+        # CONSTELLATION_MAX_COPIES - 1 (6) regardless of the raw
+        # copies_owned value — legacy rows from before this cap existed
+        # could in principle already exceed 7, and the displayed level
+        # must never read as "C7" or higher.
+        level = min(owned.copies_owned - 1, CONSTELLATION_MAX_COPIES - 1)
+        constellation = f" C{level}" if owned.copies_owned > 1 else ""
         lines.append(f"{stars} {owned.character.name}{constellation}")
     return "\n".join(lines)
 

--- a/src/ley_shards_bot/commands/collection.py
+++ b/src/ley_shards_bot/commands/collection.py
@@ -50,8 +50,11 @@ def _format_page_text(page: Page, total_owned: int) -> str:
     ]
     for owned in page.items:
         stars = RARITY_STARS[owned.character.rarity]
-        copies = f" x{owned.copies_owned}" if owned.copies_owned > 1 else ""
-        lines.append(f"{stars} {owned.character.name}{copies}")
+        # copies_owned is constellation progress (see PlayerCharacter's
+        # docstring): 1 copy = constellation 0 (no suffix shown), each
+        # copy beyond that is one constellation level.
+        constellation = f" C{owned.copies_owned - 1}" if owned.copies_owned > 1 else ""
+        lines.append(f"{stars} {owned.character.name}{constellation}")
     return "\n".join(lines)
 
 

--- a/src/ley_shards_bot/commands/gacha.py
+++ b/src/ley_shards_bot/commands/gacha.py
@@ -45,7 +45,7 @@ def _rate_up_note(outcome: gacha.PullOutcome) -> str:
     return ""
 
 
-def _duplicate_status_line(outcome: gacha.PullOutcome) -> str:
+def _outcome_status_line(outcome: gacha.PullOutcome) -> str:
     if outcome.is_new:
         return "NEW"
     if outcome.constellation_level is not None:
@@ -57,11 +57,11 @@ def _format_outcome_line(outcome: gacha.PullOutcome) -> str:
     stars = RARITY_STARS[outcome.rarity]
     return (
         f"{stars} {outcome.character.name} — {outcome.character.series} "
-        f"[{_duplicate_status_line(outcome)}]{_rate_up_note(outcome)}"
+        f"[{_outcome_status_line(outcome)}]{_rate_up_note(outcome)}"
     )
 
 
-def _duplicate_status_caption(outcome: gacha.PullOutcome) -> str:
+def _outcome_status_caption(outcome: gacha.PullOutcome) -> str:
     if outcome.is_new:
         return "✨ NEW!"
     if outcome.constellation_level is not None:
@@ -73,7 +73,7 @@ def _format_single_caption(outcome: gacha.PullOutcome) -> str:
     lines = [
         f"{RARITY_STARS[outcome.rarity]} {outcome.character.name}",
         outcome.character.series,
-        _duplicate_status_caption(outcome),
+        _outcome_status_caption(outcome),
     ]
     note = _rate_up_note(outcome)
     if note:

--- a/src/ley_shards_bot/commands/gacha.py
+++ b/src/ley_shards_bot/commands/gacha.py
@@ -45,20 +45,35 @@ def _rate_up_note(outcome: gacha.PullOutcome) -> str:
     return ""
 
 
+def _duplicate_status_line(outcome: gacha.PullOutcome) -> str:
+    if outcome.is_new:
+        return "NEW"
+    if outcome.constellation_level is not None:
+        return f"Constellation {outcome.constellation_level}!"
+    return f"dupe, +{outcome.echoes_gained} Echoes"
+
+
 def _format_outcome_line(outcome: gacha.PullOutcome) -> str:
     stars = RARITY_STARS[outcome.rarity]
-    status = "NEW" if outcome.is_new else f"dupe, +{outcome.echoes_gained} Echoes"
     return (
         f"{stars} {outcome.character.name} — {outcome.character.series} "
-        f"[{status}]{_rate_up_note(outcome)}"
+        f"[{_duplicate_status_line(outcome)}]{_rate_up_note(outcome)}"
     )
+
+
+def _duplicate_status_caption(outcome: gacha.PullOutcome) -> str:
+    if outcome.is_new:
+        return "✨ NEW!"
+    if outcome.constellation_level is not None:
+        return f"⭐ Constellation {outcome.constellation_level}!"
+    return f"Duplicate — +{outcome.echoes_gained} Echoes"
 
 
 def _format_single_caption(outcome: gacha.PullOutcome) -> str:
     lines = [
         f"{RARITY_STARS[outcome.rarity]} {outcome.character.name}",
         outcome.character.series,
-        "✨ NEW!" if outcome.is_new else f"Duplicate — +{outcome.echoes_gained} Echoes",
+        _duplicate_status_caption(outcome),
     ]
     note = _rate_up_note(outcome)
     if note:

--- a/src/ley_shards_bot/models/player_character.py
+++ b/src/ley_shards_bot/models/player_character.py
@@ -1,4 +1,10 @@
-"""Ownership: which characters a player has, and how many copies."""
+"""Ownership: which characters a player has, and their constellation
+progress. copies_owned is constellation progress, not a raw duplicate
+count: 1 = constellation 0 (base character, unlocked/unenhanced), each
+additional copy up to 7 total advances one constellation level (max
+constellation 6). See GACHA.md's "Duplicates: constellations,
+refinement, then Echoes" for the pull-time logic that enforces this.
+"""
 
 from datetime import datetime
 

--- a/src/ley_shards_bot/services/gacha.py
+++ b/src/ley_shards_bot/services/gacha.py
@@ -92,11 +92,11 @@ class PullOutcome:
     rarity: Rarity
     is_new: bool
     echoes_gained: int
-    constellation_level: int | None  # the level just reached (1-6) on a
-    # duplicate-into-level-up pull; None on a first-copy pull or on an
-    # Echoes-conversion pull (already at CONSTELLATION_MAX_COPIES). At
-    # most one of is_new/constellation_level/echoes_gained is "set" for
-    # any outcome.
+    # The level just reached (1-6) on a duplicate-into-level-up pull;
+    # None on a first-copy pull or on an Echoes-conversion pull (already
+    # at CONSTELLATION_MAX_COPIES). At most one of
+    # is_new/constellation_level/echoes_gained is "set" for any outcome.
+    constellation_level: int | None
     is_rate_up: bool | None  # None unless this was an event-banner 5-star
 
 

--- a/src/ley_shards_bot/services/gacha.py
+++ b/src/ley_shards_bot/services/gacha.py
@@ -65,6 +65,14 @@ ECHOES_PER_DUPLICATE: dict[Rarity, int] = {
     Rarity.FIVE_STAR: 50,
 }
 
+# A character's first copy is constellation 0 (unlocked, unenhanced). Each
+# subsequent duplicate advances one constellation level, up to 6 — so 7
+# total copies (1 base + 6 levels) fully constellates a character. Only
+# once a player already owns this many copies does a further duplicate
+# convert to Echoes instead of leveling anything further. See GACHA.md's
+# "Duplicates: constellations, refinement, then Echoes" section.
+CONSTELLATION_MAX_COPIES = 7
+
 
 class InsufficientLeyShardsError(Exception):
     def __init__(self, required: int, available: int) -> None:
@@ -84,6 +92,11 @@ class PullOutcome:
     rarity: Rarity
     is_new: bool
     echoes_gained: int
+    constellation_level: int | None  # the level just reached (1-6) on a
+    # duplicate-into-level-up pull; None on a first-copy pull or on an
+    # Echoes-conversion pull (already at CONSTELLATION_MAX_COPIES). At
+    # most one of is_new/constellation_level/echoes_gained is "set" for
+    # any outcome.
     is_rate_up: bool | None  # None unless this was an event-banner 5-star
 
 
@@ -176,19 +189,29 @@ def _characters_of_rarity(session: Session, rarity: Rarity) -> list[Character]:
     return list(session.scalars(select(Character).where(Character.rarity == rarity)))
 
 
-def _grant_character(session: Session, player_id: int, character: Character) -> tuple[bool, int]:
-    """Add a copy to the player's collection, or convert the duplicate to
-    Echoes. Returns (is_new, echoes_gained)."""
+def _grant_character(
+    session: Session, player_id: int, character: Character
+) -> tuple[bool, int | None, int]:
+    """Add a copy to the player's collection: a brand-new character, a
+    constellation level-up (2nd through 7th copy), or — once already at
+    the CONSTELLATION_MAX_COPIES cap — a duplicate converted to Echoes
+    instead. Returns (is_new, constellation_level, echoes_gained); at
+    most one of constellation_level/echoes_gained is set, and neither is
+    set when is_new is True."""
     ownership = session.get(PlayerCharacter, (player_id, character.anilist_id))
     if ownership is None:
         session.add(PlayerCharacter(player_id=player_id, character_id=character.anilist_id))
-        return True, 0
+        return True, None, 0
 
-    ownership.copies_owned += 1
+    if ownership.copies_owned < CONSTELLATION_MAX_COPIES:
+        ownership.copies_owned += 1
+        constellation_level = ownership.copies_owned - 1
+        return False, constellation_level, 0
+
     echoes = ECHOES_PER_DUPLICATE[character.rarity]
     player = get_or_create_player(session, player_id)
     player.echoes += echoes
-    return False, echoes
+    return False, None, echoes
 
 
 def _execute_single_pull(
@@ -229,7 +252,7 @@ def _execute_single_pull(
     if character is None:
         character = pick_character(_characters_of_rarity(session, rarity), rng)
 
-    is_new, echoes_gained = _grant_character(session, player_id, character)
+    is_new, constellation_level, echoes_gained = _grant_character(session, player_id, character)
     session.add(
         Pull(
             player_id=player_id,
@@ -244,6 +267,7 @@ def _execute_single_pull(
         rarity=rarity,
         is_new=is_new,
         echoes_gained=echoes_gained,
+        constellation_level=constellation_level,
         is_rate_up=is_rate_up,
     )
 
@@ -268,12 +292,13 @@ def pull_single(
     outcome = _execute_single_pull(session, player.telegram_user_id, banner, rng, now)
     session.commit()
     logger.info(
-        "Pull: player={} banner={} -> {} {} (new={}, echoes={}, rate_up={})",
+        "Pull: player={} banner={} -> {} {} (new={}, constellation={}, echoes={}, rate_up={})",
         player.telegram_user_id,
         banner.type,
         outcome.rarity,
         outcome.character.name,
         outcome.is_new,
+        outcome.constellation_level,
         outcome.echoes_gained,
         outcome.is_rate_up,
     )

--- a/tests/commands/test_collection.py
+++ b/tests/commands/test_collection.py
@@ -55,6 +55,26 @@ def _seed_owned_characters(engine, player_id: int, count: int) -> None:
         session.commit()
 
 
+def _seed_owned_character_with_copies(engine, player_id: int, copies_owned: int) -> None:
+    with Session(engine) as session:
+        session.add(Player(telegram_user_id=player_id))
+        session.add(
+            Character(
+                anilist_id=1,
+                name="Alpha",
+                series="Test Series",
+                image_url="https://example.invalid/1.png",
+                rarity=Rarity.THREE_STAR,
+                base_hp=50,
+                base_atk=20,
+                base_def=15,
+                base_spd=30,
+            )
+        )
+        session.add(PlayerCharacter(player_id=player_id, character_id=1, copies_owned=copies_owned))
+        session.commit()
+
+
 def _make_update(*, user_id: int = 1, chat_type: str = "private") -> MagicMock:
     update = MagicMock()
     update.effective_user.id = user_id
@@ -113,6 +133,40 @@ class TestCollectionCommand:
         buttons = [b for row in markup.inline_keyboard for b in row]
         assert any("Next" in b.text for b in buttons)
         assert not any("Prev" in b.text for b in buttons)
+
+    async def test_shows_no_constellation_suffix_for_a_single_copy(self, engine):
+        _seed_owned_character_with_copies(engine, 1, copies_owned=1)
+        update = _make_update(user_id=1)
+        context = MagicMock()
+
+        await collection_commands.collection_command(update, context)
+
+        (text,), _kwargs = update.effective_message.reply_text.call_args
+        assert "C" not in text.split("\n")[1]
+
+    async def test_shows_constellation_level_for_a_leveled_character(self, engine):
+        _seed_owned_character_with_copies(engine, 1, copies_owned=4)
+        update = _make_update(user_id=1)
+        context = MagicMock()
+
+        await collection_commands.collection_command(update, context)
+
+        (text,), _kwargs = update.effective_message.reply_text.call_args
+        assert "C3" in text
+
+    async def test_a_maxed_character_shows_c6_never_c7(self, engine):
+        """Boundary test: 7 copies (CONSTELLATION_MAX_COPIES, fully
+        maxed) must display "C6" — the highest valid level — never
+        "C7"."""
+        _seed_owned_character_with_copies(engine, 1, copies_owned=7)
+        update = _make_update(user_id=1)
+        context = MagicMock()
+
+        await collection_commands.collection_command(update, context)
+
+        (text,), _kwargs = update.effective_message.reply_text.call_args
+        assert "C6" in text
+        assert "C7" not in text
 
     async def test_rejects_outside_dm(self, engine):
         _seed_owned_characters(engine, 1, count=3)

--- a/tests/commands/test_collection.py
+++ b/tests/commands/test_collection.py
@@ -142,7 +142,7 @@ class TestCollectionCommand:
         await collection_commands.collection_command(update, context)
 
         (text,), _kwargs = update.effective_message.reply_text.call_args
-        assert "C" not in text.split("\n")[1]
+        assert " C" not in text.split("\n")[1]
 
     async def test_shows_constellation_level_for_a_leveled_character(self, engine):
         _seed_owned_character_with_copies(engine, 1, copies_owned=4)
@@ -167,6 +167,22 @@ class TestCollectionCommand:
         (text,), _kwargs = update.effective_message.reply_text.call_args
         assert "C6" in text
         assert "C7" not in text
+
+    async def test_legacy_data_above_the_cap_still_shows_c6_never_higher(self, engine):
+        """Phase 1's old duplicate-handling code had no cap, so a
+        pre-existing row could already have copies_owned above
+        CONSTELLATION_MAX_COPIES. The display must clamp regardless —
+        this must never render as "C7", "C11", etc."""
+        _seed_owned_character_with_copies(engine, 1, copies_owned=12)
+        update = _make_update(user_id=1)
+        context = MagicMock()
+
+        await collection_commands.collection_command(update, context)
+
+        (text,), _kwargs = update.effective_message.reply_text.call_args
+        assert "C6" in text
+        assert "C7" not in text
+        assert "C11" not in text
 
     async def test_rejects_outside_dm(self, engine):
         _seed_owned_characters(engine, 1, count=3)

--- a/tests/commands/test_gacha.py
+++ b/tests/commands/test_gacha.py
@@ -216,7 +216,14 @@ class TestPullTenCommand:
         assert "10-pull" not in text.lower()
 
 
-def _make_outcome(rarity: Rarity, *, character_name: str = "Frieren") -> gacha_service.PullOutcome:
+def _make_outcome(
+    rarity: Rarity,
+    *,
+    character_name: str = "Frieren",
+    is_new: bool = True,
+    constellation_level: int | None = None,
+    echoes_gained: int = 0,
+) -> gacha_service.PullOutcome:
     character = Character(
         anilist_id=99,
         name=character_name,
@@ -229,7 +236,12 @@ def _make_outcome(rarity: Rarity, *, character_name: str = "Frieren") -> gacha_s
         base_spd=1,
     )
     return gacha_service.PullOutcome(
-        character=character, rarity=rarity, is_new=True, echoes_gained=0, is_rate_up=None
+        character=character,
+        rarity=rarity,
+        is_new=is_new,
+        echoes_gained=echoes_gained,
+        constellation_level=constellation_level,
+        is_rate_up=None,
     )
 
 

--- a/tests/commands/test_gacha.py
+++ b/tests/commands/test_gacha.py
@@ -339,3 +339,37 @@ class TestRarePullGroupAnnouncement:
         for _args, kwargs in context.bot.send_message.call_args_list:
             assert kwargs["chat_id"] == -100999
             assert kwargs["message_thread_id"] == 7
+
+
+class TestFormatOutcomeLine:
+    def test_new_character(self):
+        outcome = _make_outcome(Rarity.THREE_STAR, is_new=True)
+
+        assert "[NEW]" in gacha_commands._format_outcome_line(outcome)
+
+    def test_constellation_level_up(self):
+        outcome = _make_outcome(Rarity.THREE_STAR, is_new=False, constellation_level=3)
+
+        assert "[Constellation 3!]" in gacha_commands._format_outcome_line(outcome)
+
+    def test_echoes_conversion(self):
+        outcome = _make_outcome(Rarity.FIVE_STAR, is_new=False, echoes_gained=50)
+
+        assert "[dupe, +50 Echoes]" in gacha_commands._format_outcome_line(outcome)
+
+
+class TestFormatSingleCaption:
+    def test_new_character(self):
+        outcome = _make_outcome(Rarity.THREE_STAR, is_new=True)
+
+        assert "✨ NEW!" in gacha_commands._format_single_caption(outcome)
+
+    def test_constellation_level_up(self):
+        outcome = _make_outcome(Rarity.THREE_STAR, is_new=False, constellation_level=6)
+
+        assert "⭐ Constellation 6!" in gacha_commands._format_single_caption(outcome)
+
+    def test_echoes_conversion(self):
+        outcome = _make_outcome(Rarity.FOUR_STAR, is_new=False, echoes_gained=15)
+
+        assert "Duplicate — +15 Echoes" in gacha_commands._format_single_caption(outcome)

--- a/tests/services/test_gacha.py
+++ b/tests/services/test_gacha.py
@@ -24,6 +24,7 @@ from ley_shards_bot.models import (
     Rarity,
 )
 from ley_shards_bot.services.gacha import (
+    CONSTELLATION_MAX_COPIES,
     ECHOES_PER_DUPLICATE,
     FIVE_STAR_HARD_PITY,
     FOUR_STAR_HARD_PITY,
@@ -276,26 +277,105 @@ class TestPullSingle:
         assert ownership.copies_owned == 1
         assert outcome.is_new is True
         assert outcome.echoes_gained == 0
+        assert outcome.constellation_level is None
 
-    def test_duplicate_pull_converts_to_echoes_instead_of_a_second_copy(self, session):
+    def test_duplicate_pull_levels_up_constellation_instead_of_granting_echoes(self, session):
         _seed_roster(session)
         _rich_player(session)
         banner = get_or_create_standard_banner(session)
-        # Force every roll to hit the only 3-star character by pinning the
-        # rng seed and rarity via a hard-pitied 5-star being impossible
-        # here — simplest reliable way is two pulls with a rng that lands
-        # 3-star both times isn't guaranteed by seed alone, so instead
-        # drive it directly through the pity state to keep this fast and
-        # deterministic: bottom rarity is overwhelmingly likely at pity 0.
         first = pull_single(session, PlayerRef(1), banner, rng=random.Random(1))
         second = pull_single(session, PlayerRef(1), banner, rng=random.Random(1))
 
         assert first.character.anilist_id == second.character.anilist_id
         assert second.is_new is False
-        assert second.echoes_gained == ECHOES_PER_DUPLICATE[second.rarity]
+        assert second.constellation_level == 1
+        assert second.echoes_gained == 0
+        ownership = session.get(PlayerCharacter, (1, second.character.anilist_id))
+        assert ownership is not None
+        assert ownership.copies_owned == 2
         player = session.get(Player, 1)
         assert player is not None
-        assert player.echoes == ECHOES_PER_DUPLICATE[second.rarity]
+        assert player.echoes == 0
+
+    def test_repeated_duplicates_cascade_through_constellation_levels(self, session):
+        _seed_roster(session)
+        _rich_player(session)
+        banner = get_or_create_standard_banner(session)
+
+        outcomes = [
+            pull_single(session, PlayerRef(1), banner, rng=random.Random(1)) for _ in range(3)
+        ]
+
+        character_id = outcomes[0].character.anilist_id
+        assert all(o.character.anilist_id == character_id for o in outcomes)
+        assert [o.constellation_level for o in outcomes] == [None, 1, 2]
+        ownership = session.get(PlayerCharacter, (1, character_id))
+        assert ownership is not None
+        assert ownership.copies_owned == 3
+
+    def test_duplicate_pull_converts_to_echoes_once_constellation_is_maxed(self, session):
+        _seed_roster(session)
+        _rich_player(session)
+        banner = get_or_create_standard_banner(session)
+        # Force a 5-star this pull via hard pity so it deterministically
+        # lands on the roster's one seeded 5-star character (anilist_id=5,
+        # per _seed_roster), then pre-seed that character already at the
+        # constellation cap.
+        session.add(
+            PityState(
+                player_id=1,
+                banner_type=BannerType.STANDARD,
+                pulls_since_last_5star=FIVE_STAR_HARD_PITY - 1,
+            )
+        )
+        session.add(
+            PlayerCharacter(player_id=1, character_id=5, copies_owned=CONSTELLATION_MAX_COPIES)
+        )
+        session.commit()
+
+        outcome = pull_single(session, PlayerRef(1), banner, rng=random.Random(SEED))
+
+        assert outcome.character.anilist_id == 5
+        assert outcome.is_new is False
+        assert outcome.constellation_level is None
+        assert outcome.echoes_gained == ECHOES_PER_DUPLICATE[Rarity.FIVE_STAR]
+        ownership = session.get(PlayerCharacter, (1, 5))
+        assert ownership is not None
+        assert ownership.copies_owned == CONSTELLATION_MAX_COPIES  # untouched, stays capped
+        player = session.get(Player, 1)
+        assert player is not None
+        assert player.echoes == ECHOES_PER_DUPLICATE[Rarity.FIVE_STAR]
+
+    def test_the_final_level_up_is_constellation_6_not_7(self, session):
+        """Boundary test: copies_owned climbing from 6 to 7 (the last
+        possible level-up) must report constellation_level == 6, never 7
+        — 7 total copies means levels 0 through 6 (7 states), not a level
+        7. Seeds copies_owned=6 directly (one short of the cap) rather
+        than pulling the same character 5 times first, so this test is
+        about the boundary itself, not about reproducing the cascade
+        (that's test_repeated_duplicates_cascade_through_constellation_levels's
+        job)."""
+        _seed_roster(session)
+        _rich_player(session)
+        banner = get_or_create_standard_banner(session)
+        session.add(
+            PityState(
+                player_id=1,
+                banner_type=BannerType.STANDARD,
+                pulls_since_last_5star=FIVE_STAR_HARD_PITY - 1,
+            )
+        )
+        session.add(PlayerCharacter(player_id=1, character_id=5, copies_owned=6))
+        session.commit()
+
+        outcome = pull_single(session, PlayerRef(1), banner, rng=random.Random(SEED))
+
+        assert outcome.character.anilist_id == 5
+        assert outcome.constellation_level == 6
+        assert outcome.echoes_gained == 0
+        ownership = session.get(PlayerCharacter, (1, 5))
+        assert ownership is not None
+        assert ownership.copies_owned == CONSTELLATION_MAX_COPIES
 
     def test_persists_pity_state_across_calls(self, session):
         _seed_roster(session)


### PR DESCRIPTION
Closes #21

Reinterprets `player_characters.copies_owned` as constellation progress (0-6, 7 total copies to max) instead of a raw duplicate count. A duplicate pull now advances a character one constellation level instead of immediately converting to Echoes; only once already at the 7-copy cap does a further duplicate convert to Echoes, exactly as before that point. No new column, no migration — the meaning of an existing column changes.

- `services/gacha.py`: `CONSTELLATION_MAX_COPIES = 7`; `PullOutcome` gains `constellation_level: int | None` additively (`is_new`/`echoes_gained` unchanged); `_grant_character` rewritten as a three-way branch (new / level-up / Echoes-at-cap).
- `commands/gacha.py`: `/pull`+`/pull10` reply text branches three ways ("NEW" / "Constellation N!" / "dupe, +N Echoes").
- `commands/collection.py`: `/collection` shows `C{level}` instead of a raw `x{n}` count.
- Docs updated to match (`player_character.py` docstring, `MECHANICS.md` status flips).

**Caught during final review:** the display could show "C7"/"C11"+ for legacy rows, since Phase 1's old duplicate-handling code incremented `copies_owned` with no cap. Verified directly against `moscow`'s live DB before fixing — not currently live-triggering (max `copies_owned` today is 4) — but fixed with a defensive clamp regardless, since the display must be structurally correct independent of data history. New regression test covers it.

The maximum constellation level (6, never 7) was independently boundary-tested at three layers: the pull-outcome arithmetic, the reply text, and the collection display — plus the final review walked 12 consecutive grants by hand against a real DB to confirm it holds at the integration level too.

181 tests passing, all four quality gates (ruff/ruff format/ty/qlty) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)